### PR TITLE
Add support for user agent from AFHTTPClient

### DIFF
--- a/lib/regexps.js
+++ b/lib/regexps.js
@@ -2266,5 +2266,12 @@ parser[2] = 0;
 parser[3] = 0;
 parser[4] = 0;
 exports.os[66] = parser;
+parser = Object.create(null);
+parser[0] = new RegExp("(iOS) (\\d+)\\.(\\d+)(?:\\.(\\d+))?");
+parser[1] = "iOS";
+parser[2] = 0;
+parser[3] = 0;
+parser[4] = 0;
+exports.os[67] = parser;
 
-exports.os.length = 67;
+exports.os.length = 68;


### PR DESCRIPTION
The user agent in the AFHTTPClient library looks like "iOS x.x.x".
