### PR TITLE
Add regexes for PS4 UA and OS

### DIFF
--- a/lib/regexps.js
+++ b/lib/regexps.js
@@ -1073,8 +1073,15 @@ parser[2] = 0;
 parser[3] = 0;
 parser[4] = 0;
 exports.browser[152] = parser;
+parser = Object.create(null);
+parser[0] = new RegExp("PlayStation 4.+(AppleWebKit)/(\\d+)\\.(\\d+)");
+parser[1] = "PS4 WebKit";
+parser[2] = 0;
+parser[3] = 0;
+parser[4] = 0;
+exports.browser[153] = parser;
 
-exports.browser.length = 153;
+exports.browser.length = 154;
 
 exports.device = Object.create(null);
 
@@ -2448,5 +2455,13 @@ parser[2] = 0;
 parser[3] = 0;
 parser[4] = 0;
 exports.os[77] = parser;
+parser = Object.create(null);
+parser[0] = new RegExp("(PlayStation 4) (\\d+)\\.(\\d+)");
+parser[1] = 0;
+parser[2] = 0;
+parser[3] = 0;
+parser[4] = 0;
+exports.os[78] = parser;
 
-exports.os.length = 78;
+exports.os.length = 79;
+


### PR DESCRIPTION
I am using [Karma](http://karma-runner.github.io/0.12/index.html) to run unit tests in various browsers including a PlayStation 4 web browser.

I noticed that Karma would output `Other 0.0.0 (Other 0.0.0)` when running on the PS4. I've added a couple regexes to address the issue. After the change, useragent returns `PS4 WebKit 536.26.0 (PlayStation 4 1.62)`.

I locally unit tested the change with a new test case in `test/parser.test.js` but I have not added it to this pull requests. Please let me know if you would like me to add it.

cc @3rd-Eden
