### PR TITLE
Updated benchmarks to load fixtures from the correct directory

### DIFF
--- a/benchmark/dict.js
+++ b/benchmark/dict.js
@@ -20,7 +20,7 @@ var useragent = require('../')
 /**
  * Setup the test-files.
  */
-var useragentlist = path.join(__dirname, '..', 'tests', 'fixtures', 'testcases.yaml')
+var useragentlist = path.join(__dirname, '..', 'test', 'fixtures', 'testcases.yaml')
   , yammy = yaml.eval(fs.readFileSync(useragentlist).toString()).test_cases
   , testcases = yammy.map(function (test) {
       return test.user_agent_string;

--- a/benchmark/regression.js
+++ b/benchmark/regression.js
@@ -24,7 +24,7 @@ var file = process.argv.slice(2)[0] || 'testcases';
 /**
  * Setup the test-files.
  */
-var useragentlist = path.join(__dirname, '..', 'tests', 'fixtures', file+'.yaml')
+var useragentlist = path.join(__dirname, '..', 'test', 'fixtures', file+'.yaml')
   , yammy = yaml.eval(fs.readFileSync(useragentlist).toString()).test_cases
   , testcases = yammy.map(function (test) {
       return test.user_agent_string;

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -20,7 +20,7 @@ var useragent = require('../')
 /**
  * Setup the test-files.
  */
-var useragentlist = path.join(__dirname, '..', 'tests', 'fixtures', 'testcases.yaml')
+var useragentlist = path.join(__dirname, '..', 'test', 'fixtures', 'testcases.yaml')
   , yammy = yaml.eval(fs.readFileSync(useragentlist).toString()).test_cases
   , testcases = yammy.map(function (test) {
       return test.user_agent_string;


### PR DESCRIPTION
It seems that the benchmarks are currently broken when trying to load the 'testcases.yaml' fixtures.
This PR corrects the paths.
