### PR TITLE
Moved semver to dependencies from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "long-stack-traces": "0.1.x",
     "yamlparser": "0.0.x",
     "request": "2.9.x",
-    "semver": "1.0.x",
     "pre-commit": "0.0.x"
   },
   "pre-commit": ["test", "update"],
@@ -52,6 +51,7 @@
     "prepublish": "npm run update"
   },
   "dependencies": {
-    "lru-cache": "2.2.x"
+    "lru-cache": "2.2.x",
+    "semver": "1.0.x"
   }
 }


### PR DESCRIPTION
`semver` is required at runtime but is in the `devDependencies`. At the moment it's not installed with `npm install`.