### PR TITLE
fix 69:when simulate 7 in ie11 console, will not be detected as ie

### DIFF
--- a/index.js
+++ b/index.js
@@ -531,7 +531,7 @@ exports.is = function is(useragent) {
     }
   } else if (~ua.indexOf('opera')) {
     details.opera = true;
-  } else if (~ua.indexOf('trident')) {
+  } else if (~ua.indexOf('trident') || ~ua.indexOf('msie')) {
     details.ie = true;
   } else if (~ua.indexOf('mozilla') && !~ua.indexOf('compatible')) {
     details.mozilla = true;


### PR DESCRIPTION
https://github.com/3rd-Eden/useragent/issues/69