### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,7 @@
       "web": "http://www.3rd-Eden.com"
     }
   ],
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/3rd-Eden/useragent/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/3rd-Eden/useragent.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
