### PR TITLE
Fix parsing Issue 63 https://github.com/3rd-Eden/useragent/issues/63

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,21 @@ function Agent(family, major, minor, patch, source) {
   this.source = source || '';
 }
 
+function replaceRegExResult(matches, templates) {
+    var r = [];
+    var m = matches.map(function(v){ v = typeof v === 'string' ? v.replace(/\&/g, '&&').replace(/\$/g, '&D') : v; });
+    for(var t=1; t<=4; t++) {     // template[1..4]
+        r[t] = templates[t];
+        if (typeof r[t] === 'string') {
+            for(var i=1; i<=9; i++) { // $1..$9
+                r[t] = r[t].replace(new RegExp('\\$'+i, 'g'), matches[i] != undefined ? matches[i] : '');
+            }
+            r[t] = r[t].replace(/&D/g, '$').replace(/&&/g, '&');
+        }
+    }
+    return r;
+}
+
 /**
  * OnDemand parsing of the Operating System.
  *
@@ -58,7 +73,7 @@ Object.defineProperty(Agent.prototype, 'os', {
       if (res = parsers[i][0].exec(userAgent)) {
         parser = parsers[i];
 
-        if (parser[1]) res[1] = parser[1].replace('$1', res[1]);
+        res = replaceRegExResult(res, parser);
         break;
       }
     }
@@ -68,9 +83,9 @@ Object.defineProperty(Agent.prototype, 'os', {
           ? new OperatingSystem()
           : new OperatingSystem(
                 res[1]
-              , parser[2] || res[2]
-              , parser[3] || res[3]
-              , parser[4] || res[4]
+              , res[2]
+              , res[3]
+              , res[4]
             )
     }).os;
   },
@@ -109,7 +124,7 @@ Object.defineProperty(Agent.prototype, 'device', {
       if (res = parsers[i][0].exec(userAgent)) {
         parser = parsers[i];
 
-        if (parser[1]) res[1] = parser[1].replace('$1', res[1]);
+        res = replaceRegExResult(res, parser);
         break;
       }
     }
@@ -119,9 +134,9 @@ Object.defineProperty(Agent.prototype, 'device', {
           ? new Device()
           : new Device(
                 res[1]
-              , parser[2] || res[2]
-              , parser[3] || res[3]
-              , parser[4] || res[4]
+              , res[2]
+              , res[3]
+              , res[4]
             )
     }).device;
   },
@@ -427,12 +442,12 @@ exports.parse = function parse(userAgent, jsAgent) {
     if (res = parsers[i][0].exec(userAgent)) {
       parser = parsers[i];
 
-      if (parser[1]) res[1] = parser[1].replace('$1', res[1]);
+      res = replaceRegExResult(res, parser);
       if (!jsAgent) return new Agent(
           res[1]
-        , parser[2] || res[2]
-        , parser[3] || res[3]
-        , parser[4] || res[4]
+        , res[2]
+        , res[3]
+        , res[4]
         , userAgent
       );
 

--- a/index.js
+++ b/index.js
@@ -47,11 +47,12 @@ function replaceRegExResult(matches, templates) {
     var r = [];
     var m = matches.map(function(v){ v = typeof v === 'string' ? v.replace(/\&/g, '&&').replace(/\$/g, '&D') : v; });
     for(var t=1; t<=4; t++) {     // template[1..4]
-        r[t] = templates[t];
+        var tmpl = templates[t];
+        r[t] = tmpl[0];
         if (typeof r[t] === 'string') {
-            for(var i=1; i<=9; i++) { // $1..$9
+            tmpl[1].forEach(function(i){
                 r[t] = r[t].replace(new RegExp('\\$'+i, 'g'), matches[i] != undefined ? matches[i] : '');
-            }
+            });
             r[t] = r[t].replace(/&D/g, '$').replace(/&&/g, '&');
         }
     }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ var agentparsers = regexps.browser
 var deviceparsers = regexps.device
   , deviceparserslength = deviceparsers.length;
 
+// Default for unknown version
+var UnknownFamily = 'Other';
+var UnknownVersion = '0';
+
 /**
  * The representation of a parsed user agent.
  *
@@ -32,10 +36,10 @@ var deviceparsers = regexps.device
  * @api public
  */
 function Agent(family, major, minor, patch, source) {
-  this.family = family || 'Other';
-  this.major = major || '0';
-  this.minor = minor || '0';
-  this.patch = patch || '0';
+  this.family = family || UnknownFamily;
+  this.major = major || UnknownVersion;
+  this.minor = minor || UnknownVersion;
+  this.patch = patch || UnknownVersion;
   this.source = source || '';
 }
 
@@ -176,7 +180,7 @@ Agent.prototype.toAgent = function toAgent() {
  */
 Agent.prototype.toString = function toString() {
   var agent = this.toAgent()
-    , os = this.os !== 'Other' ? this.os : false;
+    , os = this.os !== UnknownFamily ? this.os : false;
 
   return agent + (os ? ' / ' + os : '');
 };
@@ -235,10 +239,10 @@ Agent.prototype.toJSON = function toJSON() {
  * @api public
  */
 function OperatingSystem(family, major, minor, patch) {
-  this.family = family || 'Other';
-  this.major = major || '0';
-  this.minor = minor || '0';
-  this.patch = patch || '0';
+  this.family = family || UnknownFamily;
+  this.major = major || UnknownVersion;
+  this.minor = minor || UnknownVersion;
+  this.patch = patch || UnknownVersion;
 }
 
 /**
@@ -308,10 +312,10 @@ OperatingSystem.prototype.toJSON = function toJSON(){
  * @api public
  */
 function Device(family, major, minor, patch) {
-  this.family = family || 'Other';
-  this.major = major || '0';
-  this.minor = minor || '0';
-  this.patch = patch || '0';
+  this.family = family || UnknownFamily;
+  this.major = major || UnknownVersion;
+  this.minor = minor || UnknownVersion;
+  this.patch = patch || UnknownVersion;
 }
 
 /**
@@ -598,6 +602,15 @@ exports.fromJSON = function fromJSON(details) {
 
   return agent;
 };
+
+
+exports.setUnknownFamilyString = function setUnknownFamilyString(s) {
+  UnknownFamily = s;
+}
+
+exports.setUnknownVersionString = function setUnknownVersionString(s) {
+  UnknownVersion = s;
+}
 
 /**
  * Library version.

--- a/lib/update.js
+++ b/lib/update.js
@@ -50,14 +50,33 @@ exports.update = function update(callback) {
   });
 };
 
-function getReplacement(field, resource, fallback) {
+function getReplacement(field, resource, fallback, lastRepl) {
+    lastRepl = lastRepl || {};
+    var usedMap = lastRepl.usedMap || {};
+    
+    var used = [];
+    if (usedMap[fallback]) {
+        fallback = '';
+    } else {
+        used = [fallback.replace('$', '')];
+    }
+    
     if (! field)
-        return fallback;
+        return { text: fallback, used: used, usedMap: usedMap };
     if (Array.isArray(field))
         field = field.filter(function(f){ return resource[f] })[0];
-    if (resource[field] != undefined)
-        return resource[field];
-    return fallback;
+    if (! field)
+        return { text: fallback, used: used, usedMap: usedMap };
+    if (resource[field] == undefined)
+        return { text: fallback, used: used, usedMap: usedMap };
+
+    var t = resource[field];
+    var d = {};
+    var m = t.match(/\$\d/g);
+    if (m) m.forEach(function(m) { usedMap[m] = true; m = m.replace('$',''); d[m] = true;  });
+    used = Object.keys(d).sort(function(a,b){ return a-b; });
+    
+    return { text: t, used: used, usedMap: usedMap };
 }
 
 /**
@@ -136,21 +155,15 @@ exports.parse = function parse(sources, callback) {
       parser += 'parser[0] = new RegExp('+ JSON.stringify(resource.regex) + rflags + ');\n';
 
       // Check if we have replacement for the parsed family name
-      parser += 'parser[1] = "'+ getReplacement(details.replacement[0], resource, '$1').replace('"', '\\"') +'";';
+      var r = {};
+      for(var j = 0; j < 4; j++) {
+          r = getReplacement(details.replacement[j], resource, '$'+(j+1), r);
+          var used = r.used.join(', ');
+          parser += 'parser[' + (j+1) + '] = ["'+ r.text.replace('"', '\\"') +'", [' + used + ']];';
 
           parser += '\n';
+      }
 
-      parser += 'parser[2] = "'+ getReplacement(details.replacement[1], resource, '$2').replace('"', '\\"') +'";';
-
-      parser += '\n';
-
-      parser += 'parser[3] = "'+ getReplacement(details.replacement[2], resource, '$3').replace('"', '\\"') +'";';
-
-      parser += '\n';
-
-      parser += 'parser[4] = "'+ getReplacement(details.replacement[3], resource, '$4').replace('"', '\\"') +'";';
-
-      parser += '\n';
       parser += 'exports.'+ details.name +'['+ i +'] = parser;';
       results[details.resource].push(parser);
     }

--- a/lib/update.js
+++ b/lib/update.js
@@ -130,7 +130,7 @@ exports.parse = function parse(sources, callback) {
       // We need to JSON stringify the data to properly add slashes escape other
       // kinds of crap in the RegularExpression. If we don't do thing we get
       // some illegal token warnings.
-      var rflags = resource.regex_flags || '';
+      var rflags = resource.regex_flag || '';
       if (rflags) rflags = ", '" + rflags + "'";
       parser = 'parser = Object.create(null);\n';
       parser += 'parser[0] = new RegExp('+ JSON.stringify(resource.regex) + rflags + ');\n';
@@ -138,7 +138,7 @@ exports.parse = function parse(sources, callback) {
       // Check if we have replacement for the parsed family name
       parser += 'parser[1] = "'+ getReplacement(details.replacement[0], resource, '$1').replace('"', '\\"') +'";';
 
-      parser += '\n';
+          parser += '\n';
 
       parser += 'parser[2] = "'+ getReplacement(details.replacement[1], resource, '$2').replace('"', '\\"') +'";';
 

--- a/lib/update.js
+++ b/lib/update.js
@@ -50,6 +50,16 @@ exports.update = function update(callback) {
   });
 };
 
+function getReplacement(field, resource, fallback) {
+    if (! field)
+        return fallback;
+    if (Array.isArray(field))
+        field = field.filter(function(f){ return resource[f] })[0];
+    if (resource[field] != undefined)
+        return resource[field];
+    return fallback;
+}
+
 /**
  * Parse the given sources.
  *
@@ -93,17 +103,17 @@ exports.parse = function parse(sources, callback) {
   [
       {
           resource: 'user_agent_parsers'
-        , replacement: 'family_replacement'
+        , replacement: ['family_replacement', 'v1_replacement', 'v2_replacement', 'v3_replacement' ]
         , name: 'browser'
       }
     , {
           resource: 'device_parsers'
-        , replacement: 'device_replacement'
+        , replacement: [['brand_replacement', 'device_replacement' ], 'model_replacement'] // 
         , name: 'device'
       }
     , {
           resource: 'os_parsers'
-        , replacement: 'os_replacement'
+        , replacement: ['os_replacement', 'os_v1_replacement', 'os_v2_replacement' ]
         , name: 'os'
       }
   ].forEach(function parsing(details) {
@@ -120,39 +130,25 @@ exports.parse = function parse(sources, callback) {
       // We need to JSON stringify the data to properly add slashes escape other
       // kinds of crap in the RegularExpression. If we don't do thing we get
       // some illegal token warnings.
+      var rflags = resource.regex_flags || '';
+      if (rflags) rflags = ", '" + rflags + "'";
       parser = 'parser = Object.create(null);\n';
-      parser += 'parser[0] = new RegExp('+ JSON.stringify(resource.regex) + ');\n';
+      parser += 'parser[0] = new RegExp('+ JSON.stringify(resource.regex) + rflags + ');\n';
 
       // Check if we have replacement for the parsed family name
-      if (resource[details.replacement]) {
-        parser += 'parser[1] = "'+ resource[details.replacement].replace('"', '\\"') +'";';
-      } else {
-        parser += 'parser[1] = 0;';
-      }
+      parser += 'parser[1] = "'+ getReplacement(details.replacement[0], resource, '$1').replace('"', '\\"') +'";';
 
       parser += '\n';
 
-      if (resource.v1_replacement) {
-        parser += 'parser[2] = "'+ resource.v1_replacement.replace('"', '\\"') +'";';
-      } else {
-        parser += 'parser[2] = 0;';
-      }
+      parser += 'parser[2] = "'+ getReplacement(details.replacement[1], resource, '$2').replace('"', '\\"') +'";';
 
       parser += '\n';
 
-      if (resource.v2_replacement) {
-        parser += 'parser[3] = "'+ resource.v2_replacement.replace('"', '\\"') +'";';
-      } else {
-        parser += 'parser[3] = 0;';
-      }
+      parser += 'parser[3] = "'+ getReplacement(details.replacement[2], resource, '$3').replace('"', '\\"') +'";';
 
       parser += '\n';
 
-      if (resource.v3_replacement) {
-        parser += 'parser[4] = "'+ resource.v3_replacement.replace('"', '\\"') +'";';
-      } else {
-        parser += 'parser[4] = 0;';
-      }
+      parser += 'parser[4] = "'+ getReplacement(details.replacement[3], resource, '$4').replace('"', '\\"') +'";';
 
       parser += '\n';
       parser += 'exports.'+ details.name +'['+ i +'] = parser;';


### PR DESCRIPTION
Proposed solution to issue 63.

Tested with nearly 3000 agents. (using updated reg-ex)
- NO "$" left over.
- No changes to browser
- Changes in "os"
  1) 

```
  CloudyTabs/1.4 CFNetwork/720.1.1 Darwin/14.0.0 (x86_64)
  Safari/10600.4.10.7 CFNetwork/720.2.4 Darwin/14.1.0 (x86_64)
  com.apple.WebKit.WebContent/10600.4.8 CFNetwork/720.2.5 Darwin/14.1.1 (x86_64)
```

used to be "Mac OS X" version: 10
are now "Mac OS X" version: Network

```
   MobileSafari/600.1.4 CFNetwork/711.0.6 Darwin/14.0.0  
   Twitter/6.18.3 CFNetwork/711.0.6 Darwin/14.0.0
   Web/1.0 CFNetwork/711.1.12 Darwin/14.0.0
```

used to be "iOS version: 7 (or 8)
are now "iOS" version: Network

The version is wrong. This is because, I kept the behaviour of using the 2nd, 3rd and 4th match, if there is no "os_v1_replacement" (see file update.js, last argument to getReplacement())

Most of them only have "os_replacement":

```
  - regex: '(CFNetwork)/(5)48\.0\.3.* Darwin/11\.0\.0'
    os_replacement: 'iOS'
  - regex: '(CFNetwork)/(5)48\.(0)\.4.* Darwin/(1)1\.0\.0'
    os_replacement: 'iOS'
```
- Changes to "device"

Quit a lot of changes. the data is now much better allocated to

```
  ua.device.family
  ua.device.major
  ua.device.minor
```

Some example for changes (old => new)

```
iPhone5,2 / 0 / 0 => Apple / iPhone5,2 / 0       // applies to all iPad, ipod, IPhone
XT1068 / 0 / 0 => Motorola / XT1068 / 0
Samsung SM-T805 / 0 / 0 => Samsung / SM-T805 / 0
Lumia 925 / 0 / 0 => Nokia / Lumia 925 / 0
D6503 / 0 / 0 => Sony / D6503 / 0
BlackBerry 9000 / 0 / 0 => BlackBerry / 9000 / 0
LG- / E610 / 0 => LG / E610 / 0
Kindle Fire / 0 / 0 => Amazon / Kindle Fire / 0
R831K / 0 / 0 => Generic_Android / R831K / 0
ONE TOUCH 4015D / 0 / 0 => Generic_Android / ONE TOUCH 4015D / 0
ALCATEL ONE TOUCH 4030X / 0 / 0 => Generic_Android / ALCATEL ONE TOUCH 4030X / 0

Nokia / 0 / C1-01 => Nokia / C1-01 / C1-01 
```

The Nokia now has some duplication. Probably due to keeping $2, $3, $4 / see above
