### PR TITLE
Make updating regexps.js more atomic to prevent server crashes

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -38,10 +38,16 @@ exports.update = function update(callback) {
           callback(err, results);
 
           if (source && !err) {
-            fs.writeFile(exports.output, source, function idk(err) {
+            fs.writeFile(exports.output+".tmp", source, function idk(err) {
               if (err) {
-                console.error('Failed to save the generated file due to reasons', err);
+                console.error('Failed to save the temporary generated file due to reasons', err);
+                return;
               }
+              fs.rename(exports.output+".tmp", exports.output, function renameFailure(err){
+                if (err){
+                  console.error('Failed to rename the temporary file due to reasons', err);
+                }
+              });
             });
           }
         });


### PR DESCRIPTION
Occasionally the auto update fails while writing to the regexps.js file, leaving a blank file and causing node to fail and prevents starting of the application. This change writes the changes to a temporary file first and if there are no issues, then it renames it. This makes the process more atomic and has improved reliability on our servers.