### PR TITLE
Change `update` 's parameter to accept a custom remote location

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ npm install yamlparser --save
 npm install request --save
 ```
 
+You can override remote location by passing a uri string instead of a boolean:
+
+```js
+var useragent = require('useragent');
+useragent('http://my/own/regexes.yaml');
+```
+
 #### useragent.parse(useragent string[, js useragent]);
 
 This is the actual user agent parser, this is where all the magic is happening.

--- a/bin/update.js
+++ b/bin/update.js
@@ -5,7 +5,7 @@
 /**
  * Update our definition file.
  */
-require('../lib/update').update(function updating(err, data) {
+require('../lib/update').update(null, function updating(err, data) {
   if (err) {
     console.error('Update unsuccessfull due to reasons');
     console.log(err.message);

--- a/index.js
+++ b/index.js
@@ -360,12 +360,12 @@ Device.prototype.toJSON = function toJSON() {
  * Int3rNetz when we want to. We will be using the compiled version by default
  * but users can opt-in for updates.
  *
- * @param {Boolean} refresh Refresh the dataset from the remote
+ * @param {String} customRemote Refresh the dataset using data at custom remote location
  * @api public
  */
-module.exports = function updater() {
+module.exports = function updater(customRemote) {
   try {
-    require('./lib/update').update(function updating(err, results) {
+    require('./lib/update').update(customRemote, function updating(err, results) {
       if (err) {
         console.log('[useragent] Failed to update the parsed due to an error:');
         console.log('[useragent] '+ (err.message ? err.message : err));

--- a/lib/update.js
+++ b/lib/update.js
@@ -16,16 +16,19 @@ var request = require('request')
 /**
  * Update the regexp.js file
  *
+ * @param {String} customRemote Custom resource URI (default remote is used if not a string or falsy)
  * @param {Function} callback Completion callback.
  * @api public
  */
-exports.update = function update(callback) {
+exports.update = function update(customRemote, callback) {
+  var useCustomRemote = customRemote && typeof customRemote === 'string';
+
   // Prepend local additions that are missing from the source
   fs.readFile(exports.before, 'utf8', function reading(err, before) {
     if (err) return callback(err);
 
     // Fetch the remote resource as that is frequently updated
-    request(exports.remote, function downloading(err, res, remote) {
+    request(useCustomRemote ? customRemote : exports.remote, function downloading(err, res, remote) {
       if (err) return callback(err);
       if (res.statusCode !== 200) return callback(new Error('Invalid statusCode returned'));
 


### PR DESCRIPTION
Former boolean `refresh` parameter was not even used. New `customRemote`
allows user to specify its own location for the remote yaml file.
compatibility with old API (boolean as first argument) is maintained.

So I can decide to have more up-to-date regexes without having to fetch last revision from `uap-core` master

``` js
const useragent = require('useragent')
useragent('https://raw.githubusercontent.com/ua-parser/uap-core/9a83db4ce3e66ee53847070652ecfcb1e0eb0bba/regexes.yaml')
```
