### PR TITLE
Fix dev dependencies installation on Node 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "url": "http://github.com/3rd-Eden/useragent.git"
   },
   "devDependencies": {
-    "should": "*",
-    "mocha": "*",
+    "should": "1.x.x",
+    "mocha": "2.x.x",
     "long-stack-traces": "0.1.x",
     "yamlparser": "0.0.x",
     "request": "2.9.x",


### PR DESCRIPTION
Specify last major version of `mocha` and `should` compatible with Node
0.8
