### PR TITLE
[Fix] Move yamlparser to prod deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "mocha": "5.0.x",
     "pre-commit": "1.2.x",
     "request": "2.83.x",
-    "semver": "5.5.x",
-    "yamlparser": "0.0.x"
+    "semver": "5.5.x"
   },
   "pre-commit": [
     "test",
@@ -52,6 +51,7 @@
   },
   "dependencies": {
     "lru-cache": "4.1.x",
-    "tmp": "0.0.x"
+    "tmp": "0.0.x",
+    "yamlparser": "0.0.x"
   }
 }


### PR DESCRIPTION
There's a bug where a library that uses this dep fails because it doesn't install the dev deps, this is to move the `yamlparser` dep into the correct section in `package.json`.