### PR TITLE
feat: add callback support to updater function

### DIFF
--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -33,6 +33,10 @@ describe('useragent', function () {
     assume(useragent.is).is.a('function')
   });
 
+  it('should expose the updater function', function () {
+    assume(useragent).is.a('function');
+  });
+
   describe('#parse', function () {
     it('correctly transforms everything to the correct instances', function () {
       var agent = useragent.parse(ua);


### PR DESCRIPTION
Remove unused (and obviated) `refresh` param from `updater()` function and add optional `cb` param.

`cb` is an [errback (Error-First Callback)](http://fredkschott.com/post/2014/03/understanding-error-first-callbacks-in-node-js/) and, when supplied, [will be invoked with the result of `parse()`](https://github.com/3rd-Eden/useragent/blob/77e88be/lib/update.js#L39).

This unblocks work on #31.