### PR TITLE
[fix] warn about new/changed regexes on update (320159 fixes part 0)

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -15,7 +15,32 @@ var request = require('request')
   , yaml = require('yamlparser');
 
 /**
- * Update the regexp.js file
+ * Local modules.
+ */
+var old = require('./regexps');
+
+function getKnown(old) {
+  var known = new Set();
+  for (var type in old) {
+    if (!old.hasOwnProperty(type)) continue;
+    var group = old[type];
+    for (var i = 0; i < group.length; i++) {
+      var regex = group[i][0].source;
+      known.add(regex);
+    }
+  }
+  return known;
+}
+
+var known = getKnown(old);
+
+function isSafe(source) {
+  if (!/[+*{].*[+*{]/.test(source)) return true; // -35%
+  return false;
+}
+
+/**
+ * Update the regexps.js file
  *
  * @param {Function} callback Completion callback.
  * @api public
@@ -45,10 +70,8 @@ exports.update = function update(callback) {
           //
           tmp.file(function (err, tempFilePath) {
             if (err) return;
-
             fs.writeFile(tempFilePath, source, function idk(err) {
               if (err) return
-
               fs.rename(tempFilePath, exports.output, function(err) {
 
               });
@@ -68,6 +91,7 @@ exports.update = function update(callback) {
  * @api public
  */
 exports.parse = function parse(sources, callback) {
+  var unsafe = [];
   var results = {};
 
   var data = sources.reduce(function parser(memo, data) {
@@ -122,16 +146,29 @@ exports.parse = function parse(sources, callback) {
     var resources = data[details.resource]
       , name = details.resource.replace('_parsers', '')
       , resource
+      , regex
+      , source
       , parser;
 
     for (var i = 0, l = resources.length; i < l; i++) {
       resource = resources[i];
+      regex = resource.regex;
+
+      source = new RegExp(regex).source;
+      if (!known.has(source)) {
+        // A quick check, regexes not matching those are clearly safe
+        // This check excludes about 35% of all regexps we have
+        if (!isSafe(source)) {
+          unsafe.push(source);
+        }
+        known.add(source);
+      }
 
       // We need to JSON stringify the data to properly add slashes escape other
       // kinds of crap in the RegularExpression. If we don't do thing we get
       // some illegal token warnings.
       parser = 'parser = Object.create(null);\n';
-      parser += 'parser[0] = new RegExp('+ JSON.stringify(resource.regex) + ');\n';
+      parser += 'parser[0] = new RegExp('+ JSON.stringify(regex) + ');\n';
 
       // Check if we have replacement for the parsed family name
       if (resource[details.replacement]) {
@@ -169,6 +206,16 @@ exports.parse = function parse(sources, callback) {
       results[details.resource].push(parser);
     }
   });
+
+  if (unsafe.length > 0) {
+    console.log('There are new regexps! Here they are, one per line:');
+    for (var i = 0; i < unsafe.length; i++) {
+      console.log('  ' + unsafe[i]);
+    }
+    console.log('Those might be potentially unsafe and cause ReDoS.');
+    console.log('Make sure to take them through Weideman\'s tool and to inspect them!');
+    console.log('See https://github.com/NicolaasWeideman/RegexStaticAnalysis');
+  }
 
   // Generate a correct format
   exports.generate(results, callback);


### PR DESCRIPTION
This is the notification part of 320159 fixes that just highlights new or updated upstream regexps and reminds to check them thought the analysis tool.

/cc @davisjam.

It does not fix any of the existing regexps.

Ref: https://hackerone.com/reports/320159

Extracted from my private repo, as I didn't get a feedback on that.