### PR TITLE
Initialize lru-cache with new

### DIFF
--- a/index.js
+++ b/index.js
@@ -512,7 +512,8 @@ exports.parse = function parse(userAgent, jsAgent) {
  * @param {String} jsAgent Optional UA from js to detect chrome frame
  * @api public
  */
-var LRU = require('lru-cache')(5000);
+var lruCache = require('lru-cache');
+var LRU = new lruCache(5000);
 exports.lookup = function lookup(userAgent, jsAgent) {
   var key = (userAgent || '')+(jsAgent || '')
     , cached = LRU.get(key);


### PR DESCRIPTION
Fix `class constructor LRUCache cannot be invoked without 'new'`