### PR TITLE
[fix]: all long consecutive alphanums are probably evil, not just lowercase

### DIFF
--- a/index.js
+++ b/index.js
@@ -419,8 +419,11 @@ function isSafe(userAgent) {
 
   for (var i = 0; i < userAgent.length; i++) {
     code = userAgent.charCodeAt(i);
-    // numbers between 0 and 9, letters between a and z, spaces and control
-    if ((code >= 48 && code <= 57) || (code >= 97 && code <= 122) || code <= 32) {
+    if ((code >= 48 && code <= 57) || // numbers
+        (code >= 65 && code <= 90) || // letters A-Z
+        (code >= 97 && code <= 122) || // letters a-z
+        code <= 32 // spaces and control
+      ) {
       consecutive++;
     } else {
       consecutive = 0;


### PR DESCRIPTION
Earlier, all useragents with lowercase alphanum strings of 100 chars without separators were treated as unrecognised for safety (because uap-core regexes are unsafe), but that did not affect _uppercase_ strings.

Timeline:
* 64b15c94 introduced the original check.
* b18cf7c2 added lowercase letters.
* 687afe420d592488957510989f2e35976e50aa33 added spaces and control to probably evil consecutive strings
* This one adds uppercase letters, i.e. case-insensitive comparison while calculating the consecutive length.


