### PR TITLE
fix: move runtime dependencies from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,7 @@
   "devDependencies": {
     "assume": "1.5.x",
     "mocha": "5.0.x",
-    "pre-commit": "1.2.x",
-    "request": "^2.88.0",
-    "semver": "5.5.x",
-    "yamlparser": "0.0.x"
+    "pre-commit": "1.2.x"    
   },
   "pre-commit": [
     "test",
@@ -51,6 +48,9 @@
     "prepublish": "npm run update"
   },
   "dependencies": {
+    "request": "^2.88.0",
+    "yamlparser": "0.0.x",
+    "semver": "5.5.x",
     "lru-cache": "4.1.x",
     "tmp": "0.0.x"
   }


### PR DESCRIPTION
**What's the problem this PR addresses?**

`useragent` is using `semver`, `request`, and `yamlparser` at runtime without declaring them as dependencies

**How did you fix it?**

Move `semver`, `request`, and `yamlparser` from `devDependencies` to `dependencies`