### PR TITLE
[fix] move yamlparser to production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "mocha": "5.0.x",
     "pre-commit": "1.2.x",
     "request": "^2.88.0",
-    "semver": "5.5.x",
-    "yamlparser": "0.0.x"
+    "semver": "5.5.x"
   },
   "pre-commit": [
     "test",
@@ -52,6 +51,7 @@
   },
   "dependencies": {
     "lru-cache": "4.1.x",
-    "tmp": "0.0.x"
+    "tmp": "0.0.x",
+    "yamlparser": "0.0.x"
   }
 }


### PR DESCRIPTION
Yaml parser is not a dev dependency since it [is used in production code](https://github.com/3rd-Eden/useragent/blob/4c3ee79358bea72d88fe78ac98f4f861db40b89b/lib/update.js#L15), moving it to the dependencies section